### PR TITLE
refactor: 검색어 매치 정규식 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "react-icons": "^4.4.0",
     "react-router-dom": "^6.4.1",
     "react-scripts": "5.0.1",
-    "recoil": "^0.7.5",
     "styled-components": "^5.3.5",
     "styled-reset": "^4.4.2",
     "web-vitals": "^2.1.4"

--- a/src/App.js
+++ b/src/App.js
@@ -1,15 +1,11 @@
 import axiosInstance from './api';
 import { useEffect, useState } from 'react';
 
-import { useRecoilValue } from 'recoil';
-import { keywordState } from './recoil/atom';
-
 import styled from 'styled-components';
 import SearchBox from './components/SearchBox';
 
 const App = () => {
-	const keyword = useRecoilValue(keywordState);
-
+	const [keyword, setKeyword] = useState('');
 	const [results, setResults] = useState([]);
 
 	const getResults = async () => {
@@ -38,7 +34,7 @@ const App = () => {
 				<p>국내 모든 임상시험 검색하고 온라인으로 참여하기</p>
 			</Header>
 
-			<SearchBox result={results} />
+			<SearchBox result={results} keyword={keyword} setKeyword={setKeyword} />
 		</>
 	);
 };

--- a/src/App.js
+++ b/src/App.js
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 
 import styled from 'styled-components';
 import SearchBox from './components/SearchBox';
+import { getRegexIgnoreWhitespaces } from './utils/regex';
 
 const App = () => {
 	const [keyword, setKeyword] = useState('');
@@ -16,7 +17,8 @@ const App = () => {
 
 	const filterResults = async () => {
 		const response = await getResults();
-		const results = response.filter(list => list.sickNm.includes(keyword)).slice(0, 10);
+		const keywordRegex = getRegexIgnoreWhitespaces(keyword);
+		const results = response.filter(list => list.sickNm.search(keywordRegex) !== -1).slice(0, 10);
 		setResults(results);
 	};
 

--- a/src/components/SearchBox.jsx
+++ b/src/components/SearchBox.jsx
@@ -45,7 +45,7 @@ const SearchResult = ({ result, keyword, setKeyword }) => {
 		alert('검색결과로 이동합니다');
 	};
 
-	const hancldKeywords = ({ target }) => getEnterResult(target.innerText);
+	const handleKeywords = ({ target }) => getEnterResult(target.innerText);
 
 	const handleSearchClick = () => getEnterResult(keyword);
 
@@ -102,7 +102,7 @@ const SearchResult = ({ result, keyword, setKeyword }) => {
 		<SuggestionSection>
 			<p>추천 검색어로 검색해보세요</p>
 			{defaultKeywords.map((item, i) => (
-				<DefaultKeyword key={item + i} onClick={hancldKeywords}>
+				<DefaultKeyword key={item + i} onClick={handleKeywords}>
 					{item}
 				</DefaultKeyword>
 			))}
@@ -118,7 +118,7 @@ const SearchResult = ({ result, keyword, setKeyword }) => {
 					<ResultList key={i} isFocus={resultIndex === i ? true : false}>
 						<BiSearch size="20" />
 						<button
-							onClick={hancldKeywords}
+							onClick={handleKeywords}
 							dangerouslySetInnerHTML={{
 								__html: item.sickNm.replace(regex, `<strong>${keyword}</strong>`),
 							}}

--- a/src/components/SearchBox.jsx
+++ b/src/components/SearchBox.jsx
@@ -3,14 +3,12 @@ import { useRecoilState } from 'recoil';
 import { keywordState } from '../recoil/atom';
 
 import { BiSearch } from 'react-icons/bi';
-import { AiFillCloseCircle } from 'react-icons/ai';
 import {
 	SearchSection,
 	ResultSection,
 	SuggestionSection,
 	RecentSearch,
 	SearchBtn,
-	ClearBtn,
 	ResultList,
 	SearchIcon,
 	Results,
@@ -87,19 +85,18 @@ const SearchResult = ({ result }) => {
 	};
 
 	const recentSearchKeyword = (
-		<RecentSearch isShow={!keyword}>
+		<RecentSearch>
 			<p>최근 검색어</p>
-			{recentSearch.length > 0 && !keyword && (
-				<div onClick={hancldKeywords}>
-					{recentSearch.map((item, i) => (
-						// TODO : 클릭시 검색 input에 keyword 안들어감?
-						<button key={item + i}>
+			<div>
+				{recentSearch.length === 0 && <span>최근 검색어가 없습니다</span>}
+				{recentSearch.length > 0 &&
+					recentSearch?.map((item, i) => (
+						<button key={item + i} onClick={() => setKeyword(keyword)}>
 							<BiSearch size="20" />
 							{item}
 						</button>
 					))}
-				</div>
-			)}
+			</div>
 		</RecentSearch>
 	);
 
@@ -136,8 +133,6 @@ const SearchResult = ({ result }) => {
 		);
 	};
 
-	const clearResultBtn = keyword && <AiFillCloseCircle size="22" color="#aaa" onClick={() => setKeyword('')} />;
-
 	const noResult = keyword && result.length === 0 && <p>검색어 없음</p>;
 
 	return (
@@ -147,7 +142,7 @@ const SearchResult = ({ result }) => {
 					<SearchIcon size="22" />
 
 					<input
-						type="text"
+						type="search"
 						onChange={({ target }) => setKeyword(target.value)}
 						onKeyDown={handleArrowKey}
 						onFocus={() => setIsFocus(true)}
@@ -155,16 +150,15 @@ const SearchResult = ({ result }) => {
 						placeholder="질환명을 입력해주세요."
 					/>
 
-					<ClearBtn>{clearResultBtn}</ClearBtn>
-
 					<SearchBtn onClick={handleSearchClick}>
 						<BiSearch size="28" />
 					</SearchBtn>
 				</label>
 			</SearchSection>
 
-			<ResultSection isFocus={() => setIsFocus(true)} isShow={isFocus}>
-				{recentSearchKeyword}
+			<ResultSection isShow={isFocus}>
+				{!keyword && recentSearchKeyword}
+
 				{keyword && result && <p>추천 검색어</p>}
 
 				<Results ref={resultsRef}>

--- a/src/components/SearchBox.jsx
+++ b/src/components/SearchBox.jsx
@@ -115,7 +115,7 @@ const SearchResult = ({ result }) => {
 	);
 
 	const searchResults = () => {
-		const regex = new RegExp(keyword, 'g');
+		const regex = new RegExp(keyword.split('').join('\\s*'), 'gi');
 
 		return (
 			<>

--- a/src/components/SearchBox.jsx
+++ b/src/components/SearchBox.jsx
@@ -3,12 +3,14 @@ import { useRecoilState } from 'recoil';
 import { keywordState } from '../recoil/atom';
 
 import { BiSearch } from 'react-icons/bi';
+import { AiFillCloseCircle } from 'react-icons/ai';
 import {
 	SearchSection,
 	ResultSection,
 	SuggestionSection,
 	RecentSearch,
 	SearchBtn,
+	ClearBtn,
 	ResultList,
 	SearchIcon,
 	Results,
@@ -88,10 +90,10 @@ const SearchResult = ({ result }) => {
 		<RecentSearch isShow={!keyword}>
 			<p>최근 검색어</p>
 			{recentSearch.length > 0 && !keyword && (
-				<div>
+				<div onClick={hancldKeywords}>
 					{recentSearch.map((item, i) => (
 						// TODO : 클릭시 검색 input에 keyword 안들어감?
-						<button key={item + i} onClick={hancldKeywords}>
+						<button key={item + i}>
 							<BiSearch size="20" />
 							{item}
 						</button>
@@ -134,6 +136,8 @@ const SearchResult = ({ result }) => {
 		);
 	};
 
+	const clearResultBtn = keyword && <AiFillCloseCircle size="22" color="#aaa" onClick={() => setKeyword('')} />;
+
 	const noResult = keyword && result.length === 0 && <p>검색어 없음</p>;
 
 	return (
@@ -150,6 +154,8 @@ const SearchResult = ({ result }) => {
 						value={keyword || ''}
 						placeholder="질환명을 입력해주세요."
 					/>
+
+					<ClearBtn>{clearResultBtn}</ClearBtn>
 
 					<SearchBtn onClick={handleSearchClick}>
 						<BiSearch size="28" />

--- a/src/components/SearchBox.jsx
+++ b/src/components/SearchBox.jsx
@@ -14,6 +14,7 @@ import {
 } from '../styles/serach-box';
 
 import { ARROW_DOWN, ARROW_UP, ESCAPE, ENTER } from './Search.constant';
+import { getRegexIgnoreWhitespaces } from '../utils/regex';
 
 const SearchResult = ({ result, keyword, setKeyword }) => {
 	const [isFocus, setIsFocus] = useState(false);
@@ -110,21 +111,23 @@ const SearchResult = ({ result, keyword, setKeyword }) => {
 	);
 
 	const searchResults = () => {
-		const regex = new RegExp(keyword.split('').join('\\s*'), 'gi');
-
+		const regex = getRegexIgnoreWhitespaces(keyword);
 		return (
 			<>
-				{result.map((item, i) => (
-					<ResultList key={i} isFocus={resultIndex === i ? true : false}>
-						<BiSearch size="20" />
-						<button
-							onClick={handleKeywords}
-							dangerouslySetInnerHTML={{
-								__html: item.sickNm.replace(regex, `<strong>${keyword}</strong>`),
-							}}
-						/>
-					</ResultList>
-				))}
+				{result.map((item, i) => {
+					const match = item.sickNm.match(regex)?.[0];
+					return (
+						<ResultList key={i} isFocus={resultIndex === i ? true : false}>
+							<BiSearch size="20" />
+							<button
+								onClick={handleKeywords}
+								dangerouslySetInnerHTML={{
+									__html: item.sickNm.replace(regex, `<strong>${match}</strong>`),
+								}}
+							/>
+						</ResultList>
+					);
+				})}
 			</>
 		);
 	};

--- a/src/components/SearchBox.jsx
+++ b/src/components/SearchBox.jsx
@@ -1,6 +1,4 @@
 import { useRef, useState, useEffect } from 'react';
-import { useRecoilState } from 'recoil';
-import { keywordState } from '../recoil/atom';
 
 import { BiSearch } from 'react-icons/bi';
 import {
@@ -17,9 +15,7 @@ import {
 
 import { ARROW_DOWN, ARROW_UP, ESCAPE, ENTER } from './Search.constant';
 
-const SearchResult = ({ result }) => {
-	const [keyword, setKeyword] = useRecoilState(keywordState);
-
+const SearchResult = ({ result, keyword, setKeyword }) => {
 	const [isFocus, setIsFocus] = useState(false);
 	const [movePage, setMovePage] = useState(false);
 	const [resultIndex, setResultIndex] = useState(-1);

--- a/src/index.js
+++ b/src/index.js
@@ -2,16 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 
 import App from './App';
-import { RecoilRoot } from 'recoil';
 import GlobalStyles from './styles/globalStyles';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
 	<React.StrictMode>
-		<RecoilRoot>
-			<GlobalStyles />
-
-			<App />
-		</RecoilRoot>
+		<GlobalStyles />
+		<App />
 	</React.StrictMode>,
 );

--- a/src/recoil/atom.js
+++ b/src/recoil/atom.js
@@ -1,6 +1,0 @@
-import { atom } from 'recoil';
-
-export const keywordState = atom({
-	key: 'keyword',
-	default: '',
-});

--- a/src/styles/serach-box.js
+++ b/src/styles/serach-box.js
@@ -61,11 +61,6 @@ export const SearchBtn = styled.button`
 	color: white;
 `;
 
-export const ClearBtn = styled.button`
-	position: absolute;
-	right: 70px;
-`;
-
 export const ResultSection = styled.section`
 	display: ${({ isShow }) => (isShow ? 'block' : 'none')};
 	width: 490px;

--- a/src/styles/serach-box.js
+++ b/src/styles/serach-box.js
@@ -58,6 +58,11 @@ export const SearchBtn = styled.button`
 	color: white;
 `;
 
+export const ClearBtn = styled.button`
+	position: absolute;
+	right: 70px;
+`;
+
 export const ResultSection = styled.section`
 	display: ${({ isShow }) => (isShow ? 'block' : 'none')};
 	width: 490px;

--- a/src/styles/serach-box.js
+++ b/src/styles/serach-box.js
@@ -13,7 +13,7 @@ export const SearchSection = styled.section`
 			width: inherit;
 			height: inherit;
 			background-color: white;
-			padding: 20px 10px 20px 30px;
+			padding: 20px 65px 20px 30px;
 			border-radius: 42px;
 			border: 2px solid;
 			border-color: white;
@@ -27,13 +27,16 @@ export const SearchSection = styled.section`
 			&::placeholder {
 				color: #aaa;
 			}
-
 			&:focus {
 				border: 2px solid #007be9;
-
 				&::placeholder {
 					color: transparent;
 				}
+			}
+			&::-webkit-search-cancel-button {
+				width: 20px;
+				height: 20px;
+				cursor: pointer;
 			}
 		}
 	}
@@ -85,10 +88,17 @@ export const SuggestionSection = styled.section`
 `;
 
 export const RecentSearch = styled.section`
-	display: ${({ isShow }) => (isShow ? 'block' : 'none')};
 	align-items: center;
 
 	div {
+		span {
+			display: block;
+			padding: 0 0 20px 20px;
+			font-weight: bold;
+			font-size: 1.1em;
+			color: #aaa;
+		}
+
 		button {
 			width: 100%;
 			padding: 10px 20px;

--- a/src/utils/regex.js
+++ b/src/utils/regex.js
@@ -1,0 +1,2 @@
+export const getRegexIgnoreWhitespaces = keyword =>
+	new RegExp(keyword.replaceAll(/\s*/g, '').split('').join('\\s*'), 'gi');


### PR DESCRIPTION
## 네이버처럼 검색어 사이의 공백들을 무시하고 검색하도록 정규식 수정

- 네이버
![image](https://user-images.githubusercontent.com/27720475/192831916-1d7c2521-1294-444a-b8ad-256c56ae4374.png)

- 우리 앱
![image](https://user-images.githubusercontent.com/27720475/192831978-b5b9b0aa-f565-4537-b659-c9796f9e14fe.png)


